### PR TITLE
大佬，发现您的项目引入了com.fasterxml.jackson.core:jackson-databind@2.6.4组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
-	http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0   http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.song.example</groupId>
@@ -12,7 +10,7 @@
 	<properties>
         <tomcat.version>7.0.82</tomcat.version>
         <websocket.version>1.1</websocket.version>
-        <jackson.version>2.6.4</jackson.version>
+        <jackson.version>2.9.10.8</jackson.version>
     </properties>
           
     <dependencies>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：FasterXML jackson-databind反序列化漏洞(AnterosDBCPConfig gadget绕过)
缺陷组件：com.fasterxml.jackson.core:jackson-databind@2.6.4
漏洞编号：CVE-2020-9548
漏洞描述：FasterXML Jackson是美国FasterXML公司的一款适用于Java的数据处理工具。jackson-databind是其中的一个具有数据绑定功能的组件。
FasterXML jackson-databind 2.9.10.4之前的2.x版本中存在安全漏洞。攻击者可借助特制的请求利用该漏洞执行任意代码。
影响范围：(∞, 2.6.7.4)
最小修复版本：2.9.10.8
缺陷组件引入路径：com.song.example:single-room-chat@0.0.1-SNAPSHOT->com.fasterxml.jackson.core:jackson-databind@2.6.4
```
另外我运行这个项目时，IDE的安全插件提示还有64个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pd7148